### PR TITLE
Repaired buffer overflow in Tar::_init

### DIFF
--- a/src/core/lindenb/io/tarball.cpp
+++ b/src/core/lindenb/io/tarball.cpp
@@ -43,7 +43,8 @@ struct PosixTarHeader
 LOCALNS::Tar::_init(void* header)
     {
     std::memset(header,0,sizeof(PosixTarHeader));
-    std::sprintf(TARHEADER->magic,"ustar  ");
+    std::strcpy(TARHEADER->magic,"ustar");
+    std::strcpy(TARHEADER->version, " ");
     std::sprintf(TARHEADER->mtime,"%011lo",time(NULL));
     std::sprintf(TARHEADER->mode,"%07o",0644);
     char * s = ::getlogin();


### PR DESCRIPTION
Solves the #1 issue

Changed insertion into PosixTarHeader->**magic** from "ustar  " into "ustar" (without trailing spaces). According to format, the **magic** is is "_ustar and a null_" (6 characters)
The trailing spaces were used to put a space character into PosixTarHeader->**version** field, though I'm not sure why it's necessary, the gnu tar format states that version is "_00 and no null_"

The format is available [http://www.gnu.org/software/tar/manual/html_node/Standard.html](here)
